### PR TITLE
Feature/token

### DIFF
--- a/src/main/java/com/sparta/fifteen/config/WebSecurityConfig.java
+++ b/src/main/java/com/sparta/fifteen/config/WebSecurityConfig.java
@@ -2,6 +2,7 @@ package com.sparta.fifteen.config;
 
 import com.sparta.fifteen.jwt.JwtAuthenticationFilter;
 import com.sparta.fifteen.security.UserDetailsServiceImpl;
+import com.sparta.fifteen.service.token.LogoutAccessTokenService;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,8 +22,12 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class WebSecurityConfig {
 
     private final UserDetailsServiceImpl userDetailsService;
-    public WebSecurityConfig(UserDetailsServiceImpl userDetailsService){
+
+    private final LogoutAccessTokenService logoutAccessTokenService;
+
+    public WebSecurityConfig(UserDetailsServiceImpl userDetailsService, LogoutAccessTokenService logoutAccessTokenService){
         this.userDetailsService = userDetailsService;
+        this.logoutAccessTokenService = logoutAccessTokenService;
     }
 
     @Bean
@@ -37,7 +42,7 @@ public class WebSecurityConfig {
 
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception{
-        return new JwtAuthenticationFilter(userDetailsService);
+        return new JwtAuthenticationFilter(userDetailsService, logoutAccessTokenService);
     }
 
     @Bean

--- a/src/main/java/com/sparta/fifteen/controller/UserController.java
+++ b/src/main/java/com/sparta/fifteen/controller/UserController.java
@@ -5,15 +5,13 @@ import com.sparta.fifteen.dto.UserLoginRequestDto;
 import com.sparta.fifteen.dto.UserRegisterRequestDto;
 import com.sparta.fifteen.dto.UserRegisterResponseDto;
 import com.sparta.fifteen.service.UserService;
+import com.sparta.fifteen.util.JwtTokenProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.InputMismatchException;
 
@@ -50,18 +48,22 @@ public class UserController {
     }
 
     @PostMapping("/logout")
-    private ResponseEntity<?> userLogout(@RequestBody UserLoginRequestDto requestDto, HttpServletResponse response) {
+    private ResponseEntity<?> userLogout(@RequestHeader("Authorization") String authorizationHeader) {
         try {
-            // UserDetails에서 사용자 이름 가져오기
-            String userDetailsUsername = SecurityContextHolder.getContext().getAuthentication().getName();
-            // requestDto에서 사용자 이름 가져오기
-            String requestDtoUsername = requestDto.getUsername();
+            String accessToken = authorizationHeader.replace(JwtConfig.staticTokenPrefix, "");
 
+            // UserDetails에서 사용자 이름 가져오기
+            String username = SecurityContextHolder.getContext().getAuthentication().getName();
+            System.out.println(accessToken + ", " + username);
+            // requestDto에서 사용자 이름 가져오기
+            //String requestDtoUsername = requestDto.getUsername();
+
+            userService.logoutUser(accessToken, username);
             // 사용자 이름이 일치하는지 확인
-            if (userDetailsUsername.equals(requestDtoUsername)) {
+            //if (userDetailsUsername.equals(requestDtoUsername)) {
                 // 로그아웃 실행
-                userService.logoutUser(requestDtoUsername);
-            }
+
+            //}
             return ResponseEntity.ok().body("로그아웃되었습니다.");
         } catch (InputMismatchException e) {
             return ResponseEntity.badRequest().body("아이디 또는 비밀번호를 확인해주세요. 로그인에 실패하셨습니다.");

--- a/src/main/java/com/sparta/fifteen/entity/token/LogoutAccessToken.java
+++ b/src/main/java/com/sparta/fifteen/entity/token/LogoutAccessToken.java
@@ -1,0 +1,29 @@
+package com.sparta.fifteen.entity.token;
+
+import com.sparta.fifteen.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "logout_access_token")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LogoutAccessToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private long expirationTime;
+}

--- a/src/main/java/com/sparta/fifteen/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/fifteen/error/GlobalExceptionHandler.java
@@ -19,4 +19,9 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
     }
 
+    @ExceptionHandler(TokenNotFoundException.class)
+    public ResponseEntity<String> handleTokenNotFoundException(TokenNotFoundException ex){
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ex.getMessage());
+    }
+
 }

--- a/src/main/java/com/sparta/fifteen/repository/token/LogoutAccessTokenRepository.java
+++ b/src/main/java/com/sparta/fifteen/repository/token/LogoutAccessTokenRepository.java
@@ -1,0 +1,12 @@
+package com.sparta.fifteen.repository.token;
+
+import com.sparta.fifteen.entity.token.LogoutAccessToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LogoutAccessTokenRepository extends JpaRepository<LogoutAccessToken, Long> {
+    Optional<LogoutAccessToken> findByUsername(String username);
+
+    boolean existsByToken(String token);
+}

--- a/src/main/java/com/sparta/fifteen/repository/token/RefreshTokenRepository.java
+++ b/src/main/java/com/sparta/fifteen/repository/token/RefreshTokenRepository.java
@@ -11,5 +11,7 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 
     Optional<RefreshToken> findByUser(User user);
 
+    boolean existsByUser(User user);
+
     void deleteByUser(User user);
 }

--- a/src/main/java/com/sparta/fifteen/service/token/LogoutAccessTokenService.java
+++ b/src/main/java/com/sparta/fifteen/service/token/LogoutAccessTokenService.java
@@ -1,0 +1,34 @@
+package com.sparta.fifteen.service.token;
+
+import com.sparta.fifteen.entity.token.LogoutAccessToken;
+import com.sparta.fifteen.repository.token.LogoutAccessTokenRepository;
+import com.sparta.fifteen.util.JwtTokenProvider;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LogoutAccessTokenService {
+
+    private final LogoutAccessTokenRepository logoutAccessTokenRepository;
+
+    public LogoutAccessTokenService(LogoutAccessTokenRepository logoutAccessTokenRepository){
+        this.logoutAccessTokenRepository = logoutAccessTokenRepository;
+    }
+
+    public Boolean existsLogoutAccessToken(String token){
+        return logoutAccessTokenRepository.existsByToken(token);
+    }
+
+    public void saveLogoutAccessToken(String accessToken, String username){
+        long expirationTime = JwtTokenProvider.extractExpiration(accessToken).getTime();
+
+        LogoutAccessToken logoutAccessToken = logoutAccessTokenRepository.findByUsername(username)
+                .orElse(new LogoutAccessToken());
+
+        logoutAccessToken.setUsername(username);
+        logoutAccessToken.setToken(accessToken.trim()); // Bearer prefix 삭제 후 공백 남아있는 것이 문제 됨
+        logoutAccessToken.setExpirationTime(expirationTime);
+
+        logoutAccessTokenRepository.save(logoutAccessToken);
+    }
+}

--- a/src/main/java/com/sparta/fifteen/service/token/RefreshTokenService.java
+++ b/src/main/java/com/sparta/fifteen/service/token/RefreshTokenService.java
@@ -23,7 +23,7 @@ public class RefreshTokenService {
         this.refreshTokenRepository = refreshTokenRepository;
     }
 
-    public RefreshToken createRefreshToken(User user){
+    private RefreshToken createRefreshToken(User user){
 
         String token = JwtTokenProvider.generateRefreshToken();
 
@@ -32,22 +32,22 @@ public class RefreshTokenService {
         refreshToken.setToken(token);
         refreshToken.setExpirationDate(LocalDateTime.now().plusSeconds(JwtConfig.staticRefreshTokenExpirationSecond));
 
-        log.info("createRefreshToken" + refreshToken.getToken());
+        log.info("createRefreshToken: " + refreshToken.getToken());
 
         return refreshTokenRepository.save(refreshToken);
     }
 
     public RefreshToken updateRefreshToken(User user){
-        RefreshToken refreshToken = refreshTokenRepository.findByUser(user)
-                .orElseGet(() -> createRefreshToken(user));
-        log.info("updateRefreshToken" + refreshToken.getToken());
-
-
-        String token = JwtTokenProvider.generateRefreshToken();
-
-        refreshToken.updateRefreshToken(token);
-        refreshToken.updateExpirationDate(LocalDateTime.now().plusSeconds(JwtConfig.staticRefreshTokenExpirationSecond));
-        return refreshTokenRepository.save(refreshToken);
+        if(refreshTokenRepository.existsByUser(user)){
+            RefreshToken refreshToken = refreshTokenRepository.findByUser(user).get();
+            log.info("updateRefreshToken: " + refreshToken.getToken());
+            String token = JwtTokenProvider.generateRefreshToken();
+            refreshToken.updateRefreshToken(token);
+            refreshToken.updateExpirationDate(LocalDateTime.now().plusSeconds(JwtConfig.staticRefreshTokenExpirationSecond));
+            return refreshTokenRepository.save(refreshToken);
+        }else{
+            return createRefreshToken(user);
+        }
     }
 
     public User findUserByToken(String token){


### PR DESCRIPTION
로그아웃 관련.

**LogoutToken**

- 로그아웃 토큰 관련 추가.
- 유저가 로그아웃을 실행하면 access token을 유저 이름과 함께 저장.
- 유저가 인증이 필요한 다른 API를 호출 시 logout 저장소에 있는 token과 같으면 중단.

**WebSecurityConfig**

- logoutAccessTokenService 관련 추가.

**JwtAutheniticationFilter**

- 로그아웃된 토큰 관련 검증 추가.
- header가 null일 경우는 filter를 건너뛰는 과정 추가.

**RefreshToken**

- Service 내에서 create 후 update를 바로 진행하면서 두번 생성해주고 있어서 분리.

**User**
- 로그아웃 처리 수정.

**GlobalExceptionHandler**
- TokenNotFoundException 처리 추가.